### PR TITLE
Actualizar versión de la dependencia node-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "axios": "^0.22.0",
     "https": "^1.0.0",
     "jszip": "^3.7.1",
-    "node-forge": "^0.10.0",
+    "node-forge": "^1.3.1",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {


### PR DESCRIPTION
La v0.10.0 cuenta con varios problemas de seguridad.